### PR TITLE
updated gpt.el so that it uses python argument

### DIFF
--- a/gpt.el
+++ b/gpt.el
@@ -93,7 +93,7 @@ have the same meaning as for `completing-read'."
   "Start the GPT process with the given COMMAND, OUTPUT-BUFFER, and INPUT.
 Use `shell-file-name' and `shell-command-switch' to run the command in a shell.
 Send the input to the process stdin and close it."
-  (let* ((full-command (concat gpt-script-path " "
+  (let* ((full-command (concat "python " gpt-script-path " "
                                (shell-quote-argument command) " "
                                (shell-quote-argument gpt-openai-key) " "
                                (shell-quote-argument gpt-openai-engine))))

--- a/gpt.el
+++ b/gpt.el
@@ -117,7 +117,7 @@ have the same meaning as for `completing-read'."
 (defun gpt-start-process (prompt-file output-buffer)
   "Start the GPT process with the given PROMPT-FILE and OUTPUT-BUFFER.
 Use `gpt-script-path' as the executable and pass the other arguments as a list."
-  (let ((process (start-process "gpt-process" output-buffer (concat "python " gpt-script-path) gpt-openai-key gpt-openai-engine gpt-openai-max-tokens gpt-openai-temperature prompt-file)))
+  (let ((process (start-process "gpt-process" output-buffer "python" gpt-script-path gpt-openai-key gpt-openai-engine gpt-openai-max-tokens gpt-openai-temperature prompt-file)))
     process))
 
 (defun gpt-create-output-buffer (initial-buffer)


### PR DESCRIPTION
some peeople may have their setups such that opening a .py file opens it in their text editor, adding the python preamble ensures that the command works universally