### PR TITLE
Allow temperature,max-tokens and engine parameters to be overriden

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ To run a generative model command, use the `gpt-dwim` function. You can bind it 
 (global-set-key (kbd "M-C-g") 'gpt-dwim)
 ```
 
+It is possible to override gpt-openai-* parameters by passing optional temperature, max-tokens or engine parameters to `gpt-dwim`:
+
+```elisp
+(global-set-key (kbd "M-C-g") (lambda ()
+                                (interactive)
+                                (gpt-dwim :temperature "0.5"
+                                          :max-tokens "500"
+                                          :engine "text-curie-001")))
+```
+
 When you invoke `gpt-dwim`, you will be prompted for a command, with history and completion. The command can be any text. For example:
 
 ```

--- a/gpt.el
+++ b/gpt.el
@@ -47,6 +47,7 @@
 
 (add-to-list 'savehist-additional-variables 'gpt-command-history)
 
+;;;###autoload
 (defun gpt-display-command-history ()
   "Display the `gpt-command-history' in a buffer."
   (interactive)
@@ -55,6 +56,7 @@
     (insert (mapconcat #'identity gpt-command-history "\n"))
     (switch-to-buffer (current-buffer))))
 
+;;;###autoload
 (defun gpt-export-history (file)
   "Export the `gpt-command-history' to FILE."
   (interactive "FExport gpt-command-history to file: ")
@@ -84,6 +86,7 @@ have the same meaning as for `completing-read'."
         ""
       (string-trim cmd))))
 
+;;;###autoload
 (defun gpt-dwim (&rest args)
   "Run user-provided GPT command on region and print output stream."
   (interactive)


### PR DESCRIPTION
Hi Andreas,

I found myself wanting to switch between different engines/parameters quite often, so I ended up expanding gpt-dwim to allow them to be overridden!

This now allows me to bind different models to different keys easily.

Please merge this PR is you think it could be useful :)

Thanks,
Giedrius