### PR TITLE
Make sure the follow-up insertions are added to end of buffer

### DIFF
--- a/gpt.el
+++ b/gpt.el
@@ -158,6 +158,7 @@ If called with a prefix argument (i.e., ALL-BUFFERS is non-nil), use all visible
   (unless (eq major-mode 'gpt-mode)
     (user-error "Not in a gpt output buffer"))
   (let ((command (gpt-read-command)))
+    (goto-char (point-max))
     (insert "\n\n")
     (gpt-insert-command command)
     (gpt-run-buffer (current-buffer))))


### PR DESCRIPTION
Just a small fix. I noticed that if I did a follow-up from anywhere in the buffer, the follow-up command would be inserted `at-point` and not at the end of the buffer.